### PR TITLE
refactor(core): extract common logic to base classes

### DIFF
--- a/src/WART-Core/Controllers/WartBaseController.cs
+++ b/src/WART-Core/Controllers/WartBaseController.cs
@@ -1,0 +1,96 @@
+﻿// (c) 2024 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WART_Core.Entity;
+using WART_Core.Filters;
+
+namespace WART_Core.Controllers
+{
+    public abstract class WartBaseController<THub> : Controller where THub : Hub
+    {
+        private readonly ILogger _logger;
+        private readonly IHubContext<THub> _hubContext;
+        private const string RouteDataKey = "REQUEST";
+
+        protected WartBaseController(IHubContext<THub> hubContext, ILogger logger)
+        {
+            _hubContext = hubContext;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Adds the request objects to RouteData.
+        /// </summary>
+        /// <param name="context">The action executing context.</param>
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            context?.RouteData.Values.Add(RouteDataKey, context.ActionArguments);
+            base.OnActionExecuting(context);
+        }
+
+        /// <summary>
+        /// Processes the executed action and sends the event to the SignalR hub if applicable.
+        /// </summary>
+        /// <param name="context">The action executed context.</param>
+        public override async void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context?.Result is ObjectResult objectResult)
+            {
+                var exclusion = context.Filters.Any(f => f.GetType().Name == nameof(ExcludeWartAttribute));
+                if (!exclusion && context.RouteData.Values.TryGetValue(RouteDataKey, out var request))
+                {
+                    var httpMethod = context.HttpContext?.Request.Method;
+                    var httpPath = context.HttpContext?.Request.Path;
+                    var remoteAddress = context.HttpContext?.Connection.RemoteIpAddress?.ToString();
+                    var response = objectResult.Value;
+
+                    var wartEvent = new WartEvent(request, response, httpMethod, httpPath, remoteAddress);
+                    await SendToHub(wartEvent, [.. context.Filters]);
+                }
+            }
+
+            base.OnActionExecuted(context);
+        }
+
+        /// <summary>
+        /// Sends the current event to the SignalR hub.
+        /// </summary>
+        /// <param name="wartEvent">The current WartEvent.</param>
+        /// <param name="filters">The list of filters applied to the request.</param>
+        private async Task SendToHub(WartEvent wartEvent, List<IFilterMetadata> filters)
+        {
+            try
+            {
+                if (filters.Any(f => f.GetType().Name == nameof(GroupWartAttribute)))
+                {
+                    var wartGroup = filters.OfType<GroupWartAttribute>().FirstOrDefault();
+                    var groups = wartGroup?.GroupNames;
+                    if (groups != null)
+                    {
+                        foreach (var group in groups)
+                        {
+                            await _hubContext.Clients.Group(group).SendAsync("Send", wartEvent.ToString());
+                            _logger?.LogInformation($"Group: {group}, WartEvent: {wartEvent}");
+                        }
+                    }
+                }
+                else
+                {
+                    await _hubContext.Clients.All.SendAsync("Send", wartEvent.ToString());
+                    _logger?.LogInformation("Event: {EventName}, Details: {EventDetails}", nameof(WartEvent), wartEvent.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error sending WartEvent to clients");
+            }
+        }
+    }
+}

--- a/src/WART-Core/Controllers/WartController.cs
+++ b/src/WART-Core/Controllers/WartController.cs
@@ -1,15 +1,7 @@
 ﻿// (c) 2019 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using WART_Core.Entity;
-using WART_Core.Filters;
 using WART_Core.Hubs;
 
 namespace WART_Core.Controllers
@@ -17,105 +9,11 @@ namespace WART_Core.Controllers
     /// <summary>
     /// The WART Controller
     /// </summary>
-    public class WartController : Controller
+    public class WartController : WartBaseController<WartHub>
     {
-        private readonly ILogger<WartController> _logger;
-        private readonly IHubContext<WartHub> _hubContext;
-        private const string RouteDataKey = "REQUEST";
-
         public WartController(IHubContext<WartHub> hubContext, ILogger<WartController> logger)
+            : base(hubContext, logger)
         {
-            _hubContext = hubContext;
-            _logger = logger;
-        }
-
-        public WartController(IHubContext<WartHub> hubContext)
-        {
-            _hubContext = hubContext;
-        }
-
-        /// <summary>
-        /// WART OnActionExecuting override
-        /// </summary>
-        /// <param name="context">ActionExecutedContext context</param>
-        public override void OnActionExecuting(ActionExecutingContext context)
-        {
-            // add the request objects to RouteData
-            context?.RouteData.Values.Add(RouteDataKey, context.ActionArguments);
-
-            base.OnActionExecuting(context);
-        }
-
-        /// <summary>
-        /// WART OnActionExecuted override
-        /// </summary>
-        /// <param name="context">ActionExecutedContext context</param>
-        public override async void OnActionExecuted(ActionExecutedContext context)
-        {
-            if (context?.Result is ObjectResult objectResult)
-            {
-                // check for wart exclusion
-                var exclusion = context.Filters.Any(f => f.GetType().Name == nameof(ExcludeWartAttribute));
-                if (!exclusion)
-                {
-                    // check for RouteData key existence
-                    if (context.RouteData.Values.TryGetValue(RouteDataKey, out var request))
-                    {
-                        // get the request objects from RouteData
-                        var httpMethod = context.HttpContext?.Request.Method;
-                        var httpPath = context.HttpContext?.Request.Path;
-                        var remoteAddress = context.HttpContext?.Connection.RemoteIpAddress?.ToString();
-                        // get the object response
-                        var response = objectResult.Value;
-                        // create the new WartEvent and broadcast to all clients
-                        var wartEvent = new WartEvent(request, response, httpMethod, httpPath, remoteAddress);
-                        await SendToHub(wartEvent, [.. context.Filters]);
-                    }
-                }
-            }
-
-            base.OnActionExecuted(context);
-        }
-
-        /// <summary>
-        /// Send the current event to the SignalR hub.
-        /// </summary>
-        /// <param name="wartEvent">The current WartEvent</param>
-        /// <param name="filters">The current Filters</param>
-        /// <returns></returns>
-        private async Task SendToHub(WartEvent wartEvent, List<IFilterMetadata> filters)
-        {
-            try
-            {
-                // check for specific groups
-                if (filters.Any(f => f.GetType().Name == nameof(GroupWartAttribute)))
-                {
-                    // get the list of filters of type WartGroupAttribute   
-                    var wartGroup = filters.FirstOrDefault(f => f.GetType() == typeof(GroupWartAttribute)) as GroupWartAttribute;
-                    var groups = wartGroup?.GroupNames;
-                    foreach (var group in groups)
-                    {
-                        // send to the specific group
-                        await _hubContext?.Clients
-                            .Group(group)
-                            .SendAsync("Send", wartEvent.ToString());
-
-                        _logger?.LogInformation($"Group: {group}, WartEvent: {wartEvent}");
-                    }
-                }
-                else
-                {
-                    // send to all clients
-                    await _hubContext?.Clients.All
-                        .SendAsync("Send", wartEvent.ToString());
-
-                    _logger?.LogInformation("Event: {EventName}, Details: {EventDetails}", nameof(WartEvent), wartEvent.ToString());
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogError(ex, "Error sending WartEvent to clients");
-            }
         }
     }
 }

--- a/src/WART-Core/Controllers/WartControllerJwt.cs
+++ b/src/WART-Core/Controllers/WartControllerJwt.cs
@@ -1,120 +1,19 @@
 ﻿// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using System;
-using WART_Core.Entity;
 using WART_Core.Hubs;
-using System.Linq;
-using WART_Core.Filters;
-using System.Collections.Generic;
 
 namespace WART_Core.Controllers
 {
     /// <summary>
-    /// The WART Controller
+    /// The WART Controller with JWT authentication
     /// </summary>
-    public class WartControllerJwt : Controller
+    public class WartControllerJwt : WartBaseController<WartHubJwt>
     {
-        private readonly ILogger<WartControllerJwt> _logger;
-        private readonly IHubContext<WartHubJwt> _hubContext;
-        private const string RouteDataKey = "REQUEST";
-
         public WartControllerJwt(IHubContext<WartHubJwt> hubContext, ILogger<WartControllerJwt> logger)
+            : base(hubContext, logger)
         {
-            _hubContext = hubContext;
-            _logger = logger;
-        }
-
-        public WartControllerJwt(IHubContext<WartHubJwt> hubContext)
-        {
-            _hubContext = hubContext;
-        }
-
-        /// <summary>
-        /// WART OnActionExecuting override
-        /// </summary>
-        /// <param name="context">ActionExecutedContext context</param>
-        public override void OnActionExecuting(ActionExecutingContext context)
-        {
-            // add the request objects to RouteData
-            context?.RouteData.Values.Add(RouteDataKey, context.ActionArguments);
-
-            base.OnActionExecuting(context);
-        }
-
-        /// <summary>
-        /// WART OnActionExecuted override
-        /// </summary>
-        /// <param name="context">ActionExecutedContext context</param>
-        public override async void OnActionExecuted(ActionExecutedContext context)
-        {
-            if (context?.Result is ObjectResult objectResult)
-            {
-                // check for wart exclusion
-                var exclusion = context.Filters.Any(f => f.GetType().Name == nameof(ExcludeWartAttribute));
-                if (!exclusion)
-                {
-                    // check for RouteData key existence
-                    if (context.RouteData.Values.TryGetValue(RouteDataKey, out var request))
-                    {
-                        // get the request objects from RouteData
-                        var httpMethod = context.HttpContext?.Request.Method;
-                        var httpPath = context.HttpContext?.Request.Path;
-                        var remoteAddress = context.HttpContext?.Connection.RemoteIpAddress?.ToString();
-                        // get the object response
-                        var response = objectResult.Value;
-                        // create the new WartEvent and broadcast to all clients
-                        var wartEvent = new WartEvent(request, response, httpMethod, httpPath, remoteAddress);
-                        await SendToHub(wartEvent, [.. context.Filters]);
-                    }
-                }
-            }
-
-            base.OnActionExecuted(context);
-        }
-
-        /// <summary>
-        /// Send the current event to the SignalR hub.
-        /// </summary>
-        /// <param name="wartEvent">The current WartEvent</param>
-        /// <param name="filters">The current Filters</param>
-        /// <returns></returns>
-        private async Task SendToHub(WartEvent wartEvent, List<IFilterMetadata> filters)
-        {
-            try
-            {
-                // check for specific groups
-                if (filters.Any(f => f.GetType().Name == nameof(GroupWartAttribute)))
-                {
-                    // get the list of filters of type WartGroupAttribute   
-                    var wartGroup = filters.FirstOrDefault(f => f.GetType() == typeof(GroupWartAttribute)) as GroupWartAttribute;
-                    var groups = wartGroup?.GroupNames;
-                    foreach (var group in groups)
-                    {
-                        await _hubContext?.Clients
-                            .Group(group)
-                            .SendAsync("Send", wartEvent.ToString());
-
-                        _logger?.LogInformation($"Group: {group}, WartEvent: {wartEvent}");
-                    }
-                }
-                else
-                {
-                    // send to all clients
-                    await _hubContext?.Clients.All
-                        .SendAsync("Send", wartEvent.ToString());
-
-                    _logger?.LogInformation("Event: {EventName}, Details: {EventDetails}", nameof(WartEvent), wartEvent.ToString());
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogError(ex, "Error sending WartEvent to clients");
-            }
         }
     }
 }

--- a/src/WART-Core/Entity/WartEvent.cs
+++ b/src/WART-Core/Entity/WartEvent.cs
@@ -1,6 +1,7 @@
 ﻿// (c) 2019 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using WART_Core.Helpers;
 using WART_Core.Serialization;
@@ -101,5 +102,25 @@ namespace WART_Core.Entity
         {
             return SerializationHelper.Deserialize<T>(JsonResponsePayload);
         }
-    }    
+
+        /// <summary>
+        /// Converts the WartEvent instance into a dictionary for flexible logging or data analysis.
+        /// </summary>
+        /// <returns>A dictionary representation of the event.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            return new Dictionary<string, object>
+            {
+                { "EventId", EventId },
+                { "TimeStamp", TimeStamp },
+                { "UtcTimeStamp", UtcTimeStamp },
+                { "HttpMethod", HttpMethod },
+                { "HttpPath", HttpPath },
+                { "RemoteAddress", RemoteAddress },
+                { "JsonRequestPayload", JsonRequestPayload },
+                { "JsonResponsePayload", JsonResponsePayload },
+                { "ExtraInfo", ExtraInfo }
+            };
+        }
+    }
 }

--- a/src/WART-Core/Hubs/WartHub.cs
+++ b/src/WART-Core/Hubs/WartHub.cs
@@ -1,9 +1,5 @@
 ﻿// (c) 2019 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
-using System;
-using System.Collections.Concurrent;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 
 namespace WART_Core.Hubs
@@ -11,94 +7,8 @@ namespace WART_Core.Hubs
     /// <summary>
     /// The WART SignalR hub.
     /// </summary>
-    public class WartHub : Hub
+    public class WartHub : WartHubBase
     {
-        private static readonly ConcurrentDictionary<string, string> _connections = new ConcurrentDictionary<string, string>();
-
-        private readonly ILogger<WartHub> _logger;
-
-        public WartHub(ILogger<WartHub> logger)
-        {
-            _logger = logger;
-        }
-
-        public override async Task OnConnectedAsync()
-        {
-            var httpContext = Context.GetHttpContext();
-            var wartGroup = httpContext.Request.Query["WartGroup"].ToString();
-            var userName = Context.User?.Identity?.Name ?? "Anonymous";
-
-            _connections.TryAdd(Context.ConnectionId, Context.User.Identity.Name);
-
-            if (!string.IsNullOrEmpty(wartGroup))
-            {
-                await AddToGroup(wartGroup);
-            }
-
-            _logger?.LogInformation($"OnConnect: ConnectionId={Context.ConnectionId}, User={userName}");
-
-            await base.OnConnectedAsync();
-        }
-
-        public override Task OnDisconnectedAsync(Exception exception)
-        {
-            _connections.TryRemove(Context.ConnectionId, out _);
-
-            if (exception != null)
-            {
-                _logger?.LogWarning(exception, $"OnDisconnect with error: ConnectionId={Context.ConnectionId}");
-            }
-            else
-            {
-                _logger?.LogInformation($"OnDisconnect: ConnectionId={Context.ConnectionId}");
-            }
-
-            return base.OnDisconnectedAsync(exception);
-        }
-
-        /// <summary>
-        /// Adds a connection to a group.
-        /// </summary>
-        /// <param name="groupName">The group name to add the connection to.</param>
-        /// <returns></returns>
-        public async Task AddToGroup(string groupName)
-        {
-            if (string.IsNullOrWhiteSpace(groupName))
-            {
-                _logger?.LogWarning("Attempted to add to a null or empty group.");
-                return;
-            }
-
-            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
-            
-            _logger?.LogInformation($"Connection {Context.ConnectionId} added to group {groupName}");
-        }
-
-        /// <summary>
-        /// Removes a connection from a group.
-        /// </summary>
-        /// <param name="groupName">The group name to remove the connection from.</param>
-        /// <returns></returns>
-        public async Task RemoveFromGroup(string groupName)
-        {
-            if (string.IsNullOrWhiteSpace(groupName))
-            {
-                _logger?.LogWarning("Attempted to remove from a null or empty group.");
-                return;
-            }
-
-            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
-            
-            _logger?.LogInformation($"Connection {Context.ConnectionId} removed from group {groupName}");
-        }
-
-        /// <summary>
-        /// Get the current number of active connection
-        /// </summary>
-        /// <returns></returns>
-        public static int GetConnectionsCount()
-        {
-            return _connections.Count;
-        }
+        public WartHub(ILogger<WartHub> logger) : base(logger) { }
     }
 }

--- a/src/WART-Core/Hubs/WartHubBase.cs
+++ b/src/WART-Core/Hubs/WartHubBase.cs
@@ -1,0 +1,126 @@
+﻿// (c) 2024 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace WART_Core.Hubs
+{
+    /// <summary>
+    /// Base class for WART SignalR hubs. 
+    /// Provides shared logic for managing connections, groups, and logging.
+    /// </summary>
+    public abstract class WartHubBase : Hub
+    {
+        /// <summary>
+        /// Stores active connections with their respective identifiers.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, string> _connections = new ConcurrentDictionary<string, string>();
+
+        /// <summary>
+        /// Logger instance for logging hub activities.
+        /// </summary>
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WartHubBase"/> class.
+        /// </summary>
+        /// <param name="logger">Logger instance for the hub.</param>
+        protected WartHubBase(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Called when a new connection is established.
+        /// Adds the connection to the dictionary and optionally assigns it to a group.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public override async Task OnConnectedAsync()
+        {
+            var httpContext = Context.GetHttpContext();
+            var wartGroup = httpContext.Request.Query["WartGroup"].ToString();
+            var userName = Context.User?.Identity?.Name ?? "Anonymous";
+
+            _connections.TryAdd(Context.ConnectionId, userName);
+
+            if (!string.IsNullOrEmpty(wartGroup))
+            {
+                await AddToGroup(wartGroup);
+            }
+
+            _logger?.LogInformation($"OnConnect: ConnectionId={Context.ConnectionId}, User={userName}");
+
+            await base.OnConnectedAsync();
+        }
+
+        /// <summary>
+        /// Called when a connection is disconnected.
+        /// Removes the connection from the dictionary and logs the event.
+        /// </summary>
+        /// <param name="exception">The exception that occurred, if any.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public override Task OnDisconnectedAsync(Exception exception)
+        {
+            _connections.TryRemove(Context.ConnectionId, out _);
+
+            if (exception != null)
+            {
+                _logger?.LogWarning(exception, $"OnDisconnect with error: ConnectionId={Context.ConnectionId}");
+            }
+            else
+            {
+                _logger?.LogInformation($"OnDisconnect: ConnectionId={Context.ConnectionId}");
+            }
+
+            return base.OnDisconnectedAsync(exception);
+        }
+
+        /// <summary>
+        /// Adds the current connection to a specified SignalR group.
+        /// </summary>
+        /// <param name="groupName">The name of the SignalR group to add the connection to.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task AddToGroup(string groupName)
+        {
+            if (string.IsNullOrWhiteSpace(groupName))
+            {
+                _logger?.LogWarning("Attempted to add to a null or empty group.");
+                return;
+            }
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+            _logger?.LogInformation($"Connection {Context.ConnectionId} added to group {groupName}");
+        }
+
+        /// <summary>
+        /// Removes the current connection from a specified SignalR group.
+        /// </summary>
+        /// <param name="groupName">The name of the SignalR group to remove the connection from.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task RemoveFromGroup(string groupName)
+        {
+            if (string.IsNullOrWhiteSpace(groupName))
+            {
+                _logger?.LogWarning("Attempted to remove from a null or empty group.");
+                return;
+            }
+
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+            _logger?.LogInformation($"Connection {Context.ConnectionId} removed from group {groupName}");
+        }
+
+        /// <summary>
+        /// Gets the current number of active connections.
+        /// </summary>
+        /// <returns>The count of active connections.</returns>
+        public static int GetConnectionsCount()
+        {
+            return _connections.Count;
+        }
+    }
+}

--- a/src/WART-Core/Hubs/WartHubJwt.cs
+++ b/src/WART-Core/Hubs/WartHubJwt.cs
@@ -2,11 +2,7 @@
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Concurrent;
-using System.Threading.Tasks;
 
 namespace WART_Core.Hubs
 {
@@ -14,94 +10,8 @@ namespace WART_Core.Hubs
     /// The WART SignalR hub with JWT authentication.
     /// </summary>
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
-    public class WartHubJwt : Hub
+    public class WartHubJwt : WartHubBase
     {
-        private static readonly ConcurrentDictionary<string, string> _connections = new ConcurrentDictionary<string, string>();
-
-        private readonly ILogger<WartHubJwt> _logger;
-
-        public WartHubJwt(ILogger<WartHubJwt> logger)
-        {
-            _logger = logger;
-        }
-
-        public override async Task OnConnectedAsync()
-        {
-            var httpContext = Context.GetHttpContext();
-            var wartGroup = httpContext.Request.Query["WartGroup"].ToString();
-            var userName = Context.User?.Identity?.Name ?? "Anonymous";
-
-            _connections.TryAdd(Context.ConnectionId, httpContext.User.Identity.Name);
-
-            if(!string.IsNullOrEmpty(wartGroup))
-            {
-                await AddToGroup(wartGroup);
-            }
-
-            _logger?.LogInformation($"OnConnect: ConnectionId={Context.ConnectionId}, User={userName}");
-
-            await base.OnConnectedAsync();
-        }
-
-        public override Task OnDisconnectedAsync(Exception exception)
-        {
-            _connections.TryRemove(Context.ConnectionId, out _);
-
-            if (exception != null)
-            {
-                _logger?.LogWarning(exception, $"OnDisconnect with error: ConnectionId={Context.ConnectionId}");
-            }
-            else
-            {
-                _logger?.LogInformation($"OnDisconnect: ConnectionId={Context.ConnectionId}");
-            }
-
-            return base.OnDisconnectedAsync(exception);
-        }
-
-        /// <summary>
-        /// Adds a connection to a group.
-        /// </summary>
-        /// <param name="groupName">The group name to add the connection to.</param>
-        /// <returns></returns>
-        public async Task AddToGroup(string groupName)
-        {
-            if (string.IsNullOrWhiteSpace(groupName))
-            {
-                _logger?.LogWarning("Attempted to add to a null or empty group.");
-                return;
-            }
-
-            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
-
-            _logger?.LogInformation($"Connection {Context.ConnectionId} added to group {groupName}");
-        }
-
-        /// <summary>
-        /// Removes a connection from a group.
-        /// </summary>
-        /// <param name="groupName">The group name to remove the connection from.</param>
-        /// <returns></returns>
-        public async Task RemoveFromGroup(string groupName)
-        {
-            if (string.IsNullOrWhiteSpace(groupName))
-            {
-                _logger?.LogWarning("Attempted to remove from a null or empty group.");
-                return;
-            }
-
-            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
-
-            _logger?.LogInformation($"Connection {Context.ConnectionId} removed from group {groupName}");
-        }
-
-        /// <summary>
-        /// Get the current number of active connection
-        /// </summary>
-        /// <returns></returns>
-        public static int GetConnectionsCount()
-        {
-            return _connections.Count;
-        }
+        public WartHubJwt(ILogger<WartHubJwt> logger) : base(logger) { }
     }
 }

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Francesco Del Re</Authors>
     <Company>Francesco Del Re</Company>
-    <Description>WART is a C# .NET Core library that allows extending any WebApi controller and forwarding any calls received by the controller to a SignalR hub</Description>
+    <Description>Transforms REST APIs into SignalR events, bringing real-time interaction to your applications</Description>
     <Copyright>MIT</Copyright>
     <PackageProjectUrl>https://github.com/engineering87/WART</PackageProjectUrl>
     <RepositoryUrl>https://github.com/engineering87/WART</RepositoryUrl>
@@ -14,7 +14,7 @@
     <PackageLicenseExpression></PackageLicenseExpression>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <FileVersion>4.0.0.0</FileVersion>
-    <Version>5.3.3</Version>
+    <Version>5.3.4</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
- Introduced `WartBaseController`, consolidating shared functionality from `WartController` and `WartControllerJwt`.
- Simplified both controllers by inheriting from `WartBaseController` to reduce duplication.
- Extracted shared logic from `WartHub` and `WartHubJwt` into a new `WartBaseHub`.
- Both hubs now inherit from `WartBaseHub`, centralizing SignalR logic.
- Updated method signatures and reused existing utilities to enhance maintainability.