### PR TITLE
Add Cookie-Based Authentication Support for SignalR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WART is a C# .NET library that enables you to extend any Web API controller and 
 
 ## Features
 - Converts REST API calls into SignalR events, enabling real-time communication.
-- Provides controllers (`WartController`, `WartControllerJwt`) for automatic SignalR event broadcasting.
+- Provides controllers (`WartController`, `WartControllerJwt`, `WartControllerCookie`) for automatic SignalR event broadcasting.
 - Supports JWT authentication for SignalR hub connections.
 - Allows API exclusion from event broadcasting with `[ExcludeWart]` attribute.
 - Enables group-specific event dispatching with `[GroupWart("group_name")]`.
@@ -133,6 +133,18 @@ hubConnection.On<string>("Send", (data) =>
 ```
 
 In the source code you can find a simple test client and WebApi project.
+
+## Supported Authentication Modes
+
+The project supports three authentication modes for accessing the SignalR Hub:
+
+| Mode                     | Description                                                               | Hub Class           | Required Middleware      |
+|--------------------------|---------------------------------------------------------------------------|----------------------|---------------------------|
+| **No Authentication**    | Open access without identity verification                                 | `WartHub`            | None                      |
+| **JWT (Bearer Token)**   | Authentication via JWT token in the `Authorization: Bearer <token>` header | `WartHubJwt`         | `UseJwtMiddleware()`      |
+| **Cookie Authentication**| Authentication via HTTP cookies issued after login                        | `WartHubCookie`      | `UseCookieMiddleware()`   |
+
+> ⚙️ Authentication mode is selected through the `HubType` configuration in the application startup.
 
 ### Excluding APIs from Event Propagation
 There might be scenarios where you want to exclude specific APIs from propagating events to connected clients. This can be particularly useful when certain endpoints should not trigger updates, notifications, or other real-time messages through SignalR. To achieve this, you can use a custom filter called `ExcludeWartAttribute`. By decorating the desired API endpoints with this attribute, you can prevent them from being included in the SignalR event propagation logic, for example:

--- a/src/WART-Client/Program.cs
+++ b/src/WART-Client/Program.cs
@@ -22,16 +22,27 @@ namespace WART_Client
 
             Console.WriteLine($"Connecting to {wartHubUrl}");
 
-            var auth = configuration["AuthenticationJwt"];
+            var auth = configuration["AuthenticationType"] ?? "NoAuth";
 
-            if (bool.Parse(auth))
+            switch (auth.ToLowerInvariant())
             {
-                var key = configuration["Key"];
-                await WartTestClientJwt.ConnectAsync(wartHubUrl, key);
-            }
-            else
-            {
-                await WartTestClient.ConnectAsync(wartHubUrl);
+                default:
+                case "noauth":
+                    {
+                        await WartTestClient.ConnectAsync(wartHubUrl);
+                        break;
+                    }
+                case "jwt":
+                    {
+                        var key = configuration["Key"];
+                        await WartTestClientJwt.ConnectAsync(wartHubUrl, key);
+                        break;
+                    }
+                case "cookie":
+                    {
+                        await WartTestClientCookie.ConnectAsync(wartHubUrl);
+                        break;
+                    }
             }
 
             Console.WriteLine($"Connected to {wartHubUrl}");

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
   </ItemGroup>
 

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.10.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>WART_Client</RootNamespace>
     <StartupObject>WART_Client.Program</StartupObject>
 	<IsPackable>false</IsPackable>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
   </ItemGroup>
 

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 

--- a/src/WART-Client/WartTestClientCookie.cs
+++ b/src/WART-Client/WartTestClientCookie.cs
@@ -1,0 +1,91 @@
+﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WART_Client
+{
+    /// <summary>
+    /// A simple SignalR WART test client with Cookie authentication.
+    /// </summary>
+    public static class WartTestClientCookie
+    {
+        public static async Task ConnectAsync(string hubUrl)
+        {
+            try
+            {
+                var cookieContainer = new CookieContainer();
+                var handler = new HttpClientHandler
+                {
+                    CookieContainer = cookieContainer,
+                    UseCookies = true,
+                    AllowAutoRedirect = true
+                };
+
+                using var httpClient = new HttpClient(handler);
+
+                var loginContent = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("username", "test_username"),
+                    new KeyValuePair<string, string>("password", "test_password")
+                });
+
+                var loginUri = new Uri(new Uri(hubUrl), "/api/TestCookie/login");
+                var loginResponse = await httpClient.PostAsync(loginUri, loginContent);
+                loginResponse.EnsureSuccessStatusCode();
+
+                Console.WriteLine("Login successful. Connecting to SignalR...");
+
+                //var uri = new Uri(hubUrl);
+                //cookieContainer.Add(uri, new Cookie("WART.AuthCookie", "sample_value"));
+
+                var hubConnection = new HubConnectionBuilder()
+                        .WithUrl(hubUrl, options =>
+                        {
+                            options.HttpMessageHandlerFactory = _ => handler;
+                            options.Transports = HttpTransportType.WebSockets |
+                                                 HttpTransportType.ServerSentEvents |
+                                                 HttpTransportType.LongPolling;
+                        })
+                        .WithAutomaticReconnect()
+                        .Build();
+
+                hubConnection.On<string>("Send", (data) =>
+                {
+                    Console.WriteLine(data);
+                    Console.WriteLine($"Message size: {Encoding.UTF8.GetBytes(data).Length} bytes");
+                    Console.WriteLine();
+                });
+
+                hubConnection.Closed += async (ex) =>
+                {
+                    Console.WriteLine($"Connection closed: {ex?.Message}");
+                    await Task.Delay(new Random().Next(0, 5) * 1000);
+                    if (hubConnection != null)
+                        await hubConnection.StartAsync();
+                };
+
+                hubConnection.On<Exception>("ConnectionFailed", (ex) =>
+                {
+                    Console.WriteLine($"Connection failed: {ex.Message}");
+                    return Task.CompletedTask;
+                });
+
+                await hubConnection.StartAsync();
+                Console.WriteLine("SignalR connection started.");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/WART-Client/appsettings.json
+++ b/src/WART-Client/appsettings.json
@@ -3,7 +3,7 @@
   "Host": "localhost",
   "Port": "54644",
   "Hubname": "warthub",
-  "AuthenticationJwt": "true",
+  "AuthenticationType": "JWT",
   "Key": "dn3341fmcscscwe28419brhwbwgbss4t",
   "WartGroup": "SampleGroupName"
 }

--- a/src/WART-Core/Authentication/Cookie/CookieApplicationBuilderExtension.cs
+++ b/src/WART-Core/Authentication/Cookie/CookieApplicationBuilderExtension.cs
@@ -1,0 +1,22 @@
+﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using Microsoft.AspNetCore.Builder;
+
+namespace WART_Core.Authentication.Cookie
+{
+    public static class CookieApplicationBuilderExtension
+    {
+        /// <summary>
+        /// Use Cookie authentication dependency to IApplicationBuilder.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder to configure the middleware pipeline.</param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseCookieMiddleware(this IApplicationBuilder app)
+        {
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            return app;
+        }
+    }
+}

--- a/src/WART-Core/Authentication/Cookie/CookieServiceCollectionExtension.cs
+++ b/src/WART-Core/Authentication/Cookie/CookieServiceCollectionExtension.cs
@@ -1,0 +1,85 @@
+﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using WART_Core.Hubs;
+using WART_Core.Services;
+
+namespace WART_Core.Authentication.Cookie
+{
+    public static class CookieServiceCollectionExtension
+    {
+        /// <summary>
+        /// Adds Cookie authentication middleware to the service collection.
+        /// Configures the authentication parameters, SignalR settings, and response compression.
+        /// </summary>
+        /// <param name="services">The service collection to add the middleware to.</param>
+        /// <param name="loginPath">Optional path for the login redirect (default: /Account/Login).</param>
+        /// <param name="accessDeniedPath">Optional path for access denied redirect (default: /Account/Denied).</param>
+        /// <returns>The updated service collection.</returns>
+        public static IServiceCollection AddCookieMiddleware(
+            this IServiceCollection services,
+            string loginPath = "/Account/Login",
+            string accessDeniedPath = "/Account/AccessDenied")
+        {
+            // Configure forwarded headers (support for reverse proxy)
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders =
+                    ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            });
+
+            // Add logging support
+            services.AddLogging(configure => configure.AddConsole());
+
+            // Add Data Protection with key persistence
+            var keysPath = Path.Combine(AppContext.BaseDirectory, "keys");
+            Directory.CreateDirectory(keysPath);
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(new DirectoryInfo(keysPath))
+                .SetApplicationName("WART_App");
+
+            // Configure cookie-based authentication
+            services.AddAuthentication("WartCookieAuth")
+                .AddCookie("WartCookieAuth", options =>
+                {
+                    options.LoginPath = loginPath;
+                    options.AccessDeniedPath = accessDeniedPath;
+                    options.Cookie.Name = "WART.AuthCookie";
+                    options.ExpireTimeSpan = TimeSpan.FromHours(1);
+                    options.SlidingExpiration = true;
+                });
+
+            // Register WART event queue service
+            services.AddSingleton<WartEventQueueService>();
+
+            // Register the WART event worker for the cookie-authenticated hub
+            services.AddHostedService<WartEventWorker<WartHubCookie>>();
+
+            // SignalR configuration
+            services.AddSignalR(options =>
+            {
+                options.EnableDetailedErrors = true;
+                options.HandshakeTimeout = TimeSpan.FromSeconds(15);
+                options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+                options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+            });
+
+            // Compression for SignalR WebSocket/Binary transport
+            services.AddResponseCompression(opts =>
+            {
+                opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
+                    new[] { "application/octet-stream" });
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/WART-Core/Controllers/WartControllerCookie.cs
+++ b/src/WART-Core/Controllers/WartControllerCookie.cs
@@ -1,0 +1,19 @@
+﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using WART_Core.Hubs;
+
+namespace WART_Core.Controllers
+{
+    /// <summary>
+    /// The WART Controller with Cookie authentication
+    /// </summary>
+    public class WartControllerCookie : WartBaseController<WartHubCookie>
+    {
+        public WartControllerCookie(IHubContext<WartHubCookie> hubContext, ILogger<WartControllerCookie> logger)
+            : base(hubContext, logger)
+        {
+        }
+    }
+}

--- a/src/WART-Core/Enum/HubType.cs
+++ b/src/WART-Core/Enum/HubType.cs
@@ -11,9 +11,15 @@ namespace WART_Core.Enum
         /// Simple SignalR hub without authentication
         /// </summary>
         NoAuthentication,
+
         /// <summary>
         /// SignalR hub with JWT authentication
         /// </summary>
-        JwtAuthentication
+        JwtAuthentication,
+
+        /// <summary>
+        /// SignalR hub with Cookie authentication
+        /// </summary>
+        CookieAuthentication
     }
 }

--- a/src/WART-Core/Hubs/WartHubCookie.cs
+++ b/src/WART-Core/Hubs/WartHubCookie.cs
@@ -1,0 +1,16 @@
+﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
+
+namespace WART_Core.Hubs
+{
+    /// <summary>
+    /// The WART SignalR hub with Cookie-based authentication.
+    /// </summary>
+    [Authorize]
+    public class WartHubCookie : WartHubBase
+    {
+        public WartHubCookie(ILogger<WartHubCookie> logger) : base(logger) { }
+    }
+}

--- a/src/WART-Core/Middleware/WartApplicationBuilderExtension.cs
+++ b/src/WART-Core/Middleware/WartApplicationBuilderExtension.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using WART_Core.Authentication.Cookie;
 using WART_Core.Authentication.JWT;
 using WART_Core.Enum;
 using WART_Core.Hubs;
@@ -47,22 +48,38 @@ namespace WART_Core.Middleware
         {
             app.UseRouting();
 
-            if (hubType == HubType.NoAuthentication)
+            switch(hubType)
             {
-                app.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapControllers();
-                    endpoints.MapHub<WartHub>($"/{DefaultHubName}");
-                });
-            }
-            else
-            {
-                app.UseJwtMiddleware();
-                app.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapControllers();
-                    endpoints.MapHub<WartHubJwt>($"/{DefaultHubName}");
-                });
+                default:
+                case HubType.NoAuthentication:
+                    {
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapHub<WartHub>($"/{DefaultHubName}");
+                        });
+                        break;
+                    }
+                case HubType.JwtAuthentication:
+                    {
+                        app.UseJwtMiddleware();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapHub<WartHubJwt>($"/{DefaultHubName}");
+                        });
+                        break;
+                    }
+                case HubType.CookieAuthentication:
+                    {
+                        app.UseCookieMiddleware();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapHub<WartHubCookie>($"/{DefaultHubName}");
+                        });
+                        break;
+                    }
             }
 
             app.UseForwardedHeaders();
@@ -141,22 +158,38 @@ namespace WART_Core.Middleware
 
             app.UseRouting();
 
-            if (hubType == HubType.NoAuthentication)
+            switch (hubType)
             {
-                app.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapControllers();
-                    endpoints.MapHub<WartHub>($"/{hubName.Trim()}");
-                });
-            }
-            else
-            {
-                app.UseJwtMiddleware();
-                app.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapControllers();
-                    endpoints.MapHub<WartHubJwt>($"/{hubName.Trim()}");
-                });
+                default:
+                case HubType.NoAuthentication:
+                    {
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapHub<WartHub>($"/{hubName.Trim()}");
+                        });
+                        break;
+                    }
+                case HubType.JwtAuthentication:
+                    {
+                        app.UseJwtMiddleware();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapHub<WartHubJwt>($"/{hubName.Trim()}");
+                        });
+                        break;
+                    }
+                case HubType.CookieAuthentication:
+                    {
+                        app.UseCookieMiddleware();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapHub<WartHubCookie>($"/{hubName.Trim()}");
+                        });
+                        break;
+                    }
             }
 
             app.UseForwardedHeaders();
@@ -183,22 +216,38 @@ namespace WART_Core.Middleware
 
             foreach (var hubName in hubNameList.Distinct())
             {
-                if (hubType == HubType.NoAuthentication)
+                switch (hubType)
                 {
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.MapControllers();
-                        endpoints.MapHub<WartHub>($"/{hubName.Trim()}");
-                    });
-                }
-                else
-                {
-                    app.UseJwtMiddleware();
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.MapControllers();
-                        endpoints.MapHub<WartHubJwt>($"/{hubName.Trim()}");
-                    });
+                    default:
+                    case HubType.NoAuthentication:
+                        {
+                            app.UseEndpoints(endpoints =>
+                            {
+                                endpoints.MapControllers();
+                                endpoints.MapHub<WartHub>($"/{hubName.Trim()}");
+                            });
+                            break;
+                        }
+                    case HubType.JwtAuthentication:
+                        {
+                            app.UseJwtMiddleware();
+                            app.UseEndpoints(endpoints =>
+                            {
+                                endpoints.MapControllers();
+                                endpoints.MapHub<WartHubJwt>($"/{hubName.Trim()}");
+                            });
+                            break;
+                        }
+                    case HubType.CookieAuthentication:
+                        {
+                            app.UseCookieMiddleware();
+                            app.UseEndpoints(endpoints =>
+                            {
+                                endpoints.MapControllers();
+                                endpoints.MapHub<WartHubCookie>($"/{hubName.Trim()}");
+                            });
+                            break;
+                        }
                 }
             }
 

--- a/src/WART-Core/Middleware/WartServiceCollectionExtension.cs
+++ b/src/WART-Core/Middleware/WartServiceCollectionExtension.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
+using WART_Core.Authentication.Cookie;
 using WART_Core.Authentication.JWT;
 using WART_Core.Enum;
 using WART_Core.Hubs;
@@ -70,15 +71,27 @@ namespace WART_Core.Middleware
         public static IServiceCollection AddWartMiddleware(this IServiceCollection services, HubType hubType, string tokenKey = "")
         {
             // Check the hub type to determine if authentication is required.
-            if (hubType == HubType.NoAuthentication)
+            switch(hubType)
             {
-                // If no authentication is required, configure WART middleware without authentication.
-                services.AddWartMiddleware();
-            }
-            else
-            {
-                // If authentication is required, configure JWT middleware for authentication.
-                services.AddJwtMiddleware(tokenKey);
+                default:
+                case HubType.NoAuthentication:
+                    {
+                        // If no authentication is required, configure WART middleware without authentication.
+                        services.AddWartMiddleware();
+                        break;
+                    }
+                case HubType.JwtAuthentication:
+                    {
+                        // If authentication is required, configure JWT middleware for authentication.
+                        services.AddJwtMiddleware(tokenKey);
+                        break;
+                    }
+                case HubType.CookieAuthentication:
+                    {
+                        // If authentication is required, configure Cookie middleware for authentication.
+                        services.AddCookieMiddleware();
+                        break;
+                    }
             }
 
             return services;

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>WART_Core</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Francesco Del Re</Authors>
@@ -14,7 +14,7 @@
     <PackageLicenseExpression></PackageLicenseExpression>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <FileVersion>4.0.0.0</FileVersion>
-    <Version>5.3.4</Version>
+    <Version>5.4.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -22,8 +22,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
-    <PackageReference Include="System.Text.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -22,8 +22,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -22,8 +22,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -22,8 +22,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -22,8 +22,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -15,11 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>WART_Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -11,14 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/WART-WebApiRealTime/Controllers/TestCookieController.cs
+++ b/src/WART-WebApiRealTime/Controllers/TestCookieController.cs
@@ -1,0 +1,126 @@
+﻿// (c) 2025 Francesco Del Re <francesco.delre.87@gmail.com>
+// This code is licensed under MIT license (see LICENSE.txt for details)
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using WART_Api.Entity;
+using WART_Core.Controllers;
+using WART_Core.Filters;
+using WART_Core.Hubs;
+
+namespace WART_Api.Controllers
+{
+    /// <summary>
+    /// A simple controller example extended by the WartController with Cookie authentication.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TestCookieController : WartControllerCookie
+    {
+        private static List<TestEntity> Items = new List<TestEntity>
+            {
+                new TestEntity { Id = 1, Param = "Item1" },
+                new TestEntity { Id = 2, Param = "Item2" },
+                new TestEntity { Id = 3, Param = "Item3" }
+            };
+
+        public TestCookieController(IHubContext<WartHubCookie> messageHubContext, ILogger<TestCookieController> logger) : base(messageHubContext, logger)
+        {
+        }
+
+        // Login endpoint: issues authentication cookie using "WartCookieAuth" scheme
+        [HttpPost("login")]
+        [ExcludeWart] // Exclude from event interception if using custom filters
+        public async Task<IActionResult> Login([FromForm] string username, [FromForm] string password)
+        {
+            if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+            {
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Name, username)
+                };
+
+                var identity = new ClaimsIdentity(claims, "WartCookieAuth");
+                var principal = new ClaimsPrincipal(identity);
+
+                await HttpContext.SignInAsync("WartCookieAuth", principal, new AuthenticationProperties
+                {
+                    IsPersistent = true,
+                    ExpiresUtc = DateTime.UtcNow.AddHours(1)
+                });
+
+                return Ok("Login successful.");
+            }
+
+            return Unauthorized("Invalid credentials.");
+        }
+
+        [HttpGet]
+        public IEnumerable<TestEntity> Get()
+        {
+            return Items;
+        }
+
+        [HttpGet("{id}")]
+        [ExcludeWart]
+        public ActionResult<TestEntity> Get(int id)
+        {
+            var item = Items.FirstOrDefault(x => x.Id == id);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            return item;
+        }
+
+        [HttpPost]
+        [GroupWart("SampleGroupName")]
+        public ActionResult<TestEntity> Post([FromBody] TestEntity entity)
+        {
+            Items.Add(entity);
+            return entity;
+        }
+
+        [HttpPatch("{id}")]
+        public ActionResult<TestEntity> Patch(int id, [FromBody] TestEntity entity)
+        {
+            var item = Items.FirstOrDefault(x => x.Id == id);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            item.Param = entity.Param;
+            return item;
+        }
+
+        [HttpPut("{id}")]
+        public ActionResult<TestEntity> Put(int id, [FromBody] TestEntity entity)
+        {
+            var item = Items.FirstOrDefault(x => x.Id == id);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            item.Param = entity.Param;
+            return item;
+        }
+
+        [HttpDelete("{id}")]
+        public ActionResult<TestEntity> Delete(int id)
+        {
+            var item = Items.FirstOrDefault(x => x.Id == id);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            Items.Remove(item);
+            return item;
+        }
+    }
+}

--- a/src/WART-WebApiRealTime/Startup.cs
+++ b/src/WART-WebApiRealTime/Startup.cs
@@ -28,10 +28,15 @@ namespace WART_Api
             services.AddControllers();
 
             // add the Wart middleware service extension
-            // default without authentication
+
+            // default without authentication            
             //services.AddWartMiddleware();
-            // with authentication
-            services.AddWartMiddleware(hubType: HubType.JwtAuthentication, tokenKey: "dn3341fmcscscwe28419brhwbwgbss4t");
+
+            // with JWT authentication
+            //services.AddWartMiddleware(hubType: HubType.JwtAuthentication, tokenKey: "dn3341fmcscscwe28419brhwbwgbss4t");
+
+            // with Cookie authentication
+            services.AddWartMiddleware(hubType: HubType.CookieAuthentication);
 
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
@@ -69,8 +74,11 @@ namespace WART_Api
             // default without authentication
             //app.UseWartMiddleware();
 
-            // with authentication
-            app.UseWartMiddleware(HubType.JwtAuthentication);
+            // with JWT authentication
+            //app.UseWartMiddleware(HubType.JwtAuthentication);
+
+            // with Cookie authentication
+            app.UseWartMiddleware(HubType.CookieAuthentication);
 
             // multiple hub with authentication
             //var hubNameList = new List<string>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>WART_Api</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	<IsPackable>false</IsPackable>


### PR DESCRIPTION
### Summary
This PR adds support for authenticating SignalR connections via browser cookies.