### PR TITLE
fix: security hardening for SignalR hub authentication and group subscription

### DIFF
--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WART-Client/WART-Client.csproj
+++ b/src/WART-Client/WART-Client.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
   </ItemGroup>
 

--- a/src/WART-Core/Authentication/JWT/JwtServiceCollectionExtension.cs
+++ b/src/WART-Core/Authentication/JWT/JwtServiceCollectionExtension.cs
@@ -27,9 +27,12 @@ namespace WART_Core.Authentication.JWT
         /// </summary>
         /// <param name="services">The service collection to add the middleware to.</param>
         /// <param name="tokenKey">The secret key used to sign and validate the JWT tokens.</param>
+        /// <param name="validIssuer">Optional. When provided, JWT issuer validation is enabled and tokens must match this value.</param>
+        /// <param name="validAudience">Optional. When provided, JWT audience validation is enabled and tokens must match this value.</param>
         /// <returns>The updated service collection.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the token key is null or empty.</exception>
-        public static IServiceCollection AddJwtMiddleware(this IServiceCollection services, string tokenKey)
+        public static IServiceCollection AddJwtMiddleware(this IServiceCollection services, string tokenKey,
+            string validIssuer = null, string validAudience = null)
         {
             // Validate that the token key is provided
             if (string.IsNullOrEmpty(tokenKey))
@@ -64,8 +67,10 @@ namespace WART_Core.Authentication.JWT
                     new TokenValidationParameters
                     {
                         LifetimeValidator = (before, expires, token, parameters) => expires != null && expires > DateTime.UtcNow,
-                        ValidateAudience = false,
-                        ValidateIssuer = false,
+                        ValidateAudience = !string.IsNullOrEmpty(validAudience),
+                        ValidAudience = validAudience,
+                        ValidateIssuer = !string.IsNullOrEmpty(validIssuer),
+                        ValidIssuer = validIssuer,
                         ValidateActor = false,
                         ValidateLifetime = true,
                         ValidateIssuerSigningKey = true,

--- a/src/WART-Core/Enum/HubType.cs
+++ b/src/WART-Core/Enum/HubType.cs
@@ -1,5 +1,7 @@
-﻿// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
+// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
+using System;
+
 namespace WART_Core.Enum
 {
     /// <summary>
@@ -8,8 +10,19 @@ namespace WART_Core.Enum
     public enum HubType
     {
         /// <summary>
-        /// Simple SignalR hub without authentication
+        /// Simple SignalR hub without authentication.
         /// </summary>
+        /// <remarks>
+        /// <b>SECURITY WARNING:</b> This mode maps an unauthenticated SignalR hub that broadcasts
+        /// live API request and response payloads to every connected client with no credential check.
+        /// Any anonymous network client can connect and receive sensitive data (request bodies,
+        /// response bodies, HTTP paths). Use <see cref="JwtAuthentication"/> or
+        /// <see cref="CookieAuthentication"/> instead.
+        /// See https://github.com/engineering87/WART/security/advisories
+        /// </remarks>
+        [Obsolete("NoAuthentication broadcasts all API events to any anonymous client and is insecure. " +
+                  "Use HubType.JwtAuthentication or HubType.CookieAuthentication instead. " +
+                  "See https://github.com/engineering87/WART/security/advisories")]
         NoAuthentication,
 
         /// <summary>

--- a/src/WART-Core/Hubs/WartHub.cs
+++ b/src/WART-Core/Hubs/WartHub.cs
@@ -5,10 +5,16 @@ using Microsoft.Extensions.Logging;
 namespace WART_Core.Hubs
 {
     /// <summary>
-    /// The WART SignalR hub.
+    /// The WART SignalR hub (unauthenticated).
+    /// Group subscriptions are not permitted on this hub because connections
+    /// carry no verified identity. Use <see cref="WartHubJwt"/> or
+    /// <see cref="WartHubCookie"/> when group-scoped event delivery is required.
     /// </summary>
     public class WartHub : WartHubBase
     {
         public WartHub(ILogger<WartHub> logger) : base(logger) { }
+
+        /// <inheritdoc />
+        protected override bool IsGroupSubscriptionAllowed() => false;
     }
 }

--- a/src/WART-Core/Hubs/WartHubBase.cs
+++ b/src/WART-Core/Hubs/WartHubBase.cs
@@ -52,7 +52,16 @@ namespace WART_Core.Hubs
 
             if (!string.IsNullOrEmpty(wartGroup))
             {
-                await AddToGroup(wartGroup);
+                if (IsGroupSubscriptionAllowed())
+                {
+                    await AddToGroup(wartGroup);
+                }
+                else
+                {
+                    _logger?.LogWarning(
+                        "Group subscription denied for ConnectionId={ConnectionId}, User={User}: hub does not permit group subscriptions.",
+                        Context.ConnectionId, LogSanitizer.Sanitize(userName));
+                }
             }
 
             _logger?.LogInformation("OnConnected: ConnectionId={ConnectionId}, User={User}",
@@ -84,6 +93,17 @@ namespace WART_Core.Hubs
             }
 
             return base.OnDisconnectedAsync(exception);
+        }
+
+        /// <summary>
+        /// Determines whether the current connection is allowed to subscribe to a SignalR group.
+        /// Authenticated hubs return <c>true</c> only when the connecting principal is authenticated.
+        /// The default unauthenticated <see cref="WartHub"/> overrides this to return <c>false</c>.
+        /// </summary>
+        /// <returns><c>true</c> if group subscription is permitted; otherwise <c>false</c>.</returns>
+        protected virtual bool IsGroupSubscriptionAllowed()
+        {
+            return Context.User?.Identity?.IsAuthenticated == true;
         }
 
         /// <summary>

--- a/src/WART-Core/Middleware/WartApplicationBuilderExtension.cs
+++ b/src/WART-Core/Middleware/WartApplicationBuilderExtension.cs
@@ -1,4 +1,4 @@
-ï»¿// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
+// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using Microsoft.AspNetCore.Builder;
 using System;
@@ -31,6 +31,16 @@ namespace WART_Core.Middleware
         /// </summary>
         /// <param name="app">The IApplicationBuilder to configure the middleware pipeline.</param>
         /// <returns>The updated IApplicationBuilder to continue configuration.</returns>
+        /// <remarks>
+        /// <b>SECURITY WARNING:</b> This overload maps an unauthenticated SignalR hub that broadcasts
+        /// live API request and response payloads to every connected client with no credential check.
+        /// Use <see cref="UseWartMiddleware(IApplicationBuilder, HubType)"/> with
+        /// <c>HubType.JwtAuthentication</c> or <c>HubType.CookieAuthentication</c> instead.
+        /// See https://github.com/engineering87/WART/security/advisories
+        /// </remarks>
+        [Obsolete("UseWartMiddleware() without authentication broadcasts all API events to any anonymous client and is insecure. " +
+                  "Use UseWartMiddleware(HubType.JwtAuthentication) or UseWartMiddleware(HubType.CookieAuthentication) instead. " +
+                  "See https://github.com/engineering87/WART/security/advisories")]
         public static IApplicationBuilder UseWartMiddleware(this IApplicationBuilder app)
         {
             app.UseForwardedHeaders();
@@ -63,6 +73,7 @@ namespace WART_Core.Middleware
             switch(hubType)
             {
                 default:
+#pragma warning disable CS0618 // Internal routing — intentional fallback to no-auth mode
                 case HubType.NoAuthentication:
                     {
                         app.UseEndpoints(endpoints =>
@@ -72,6 +83,7 @@ namespace WART_Core.Middleware
                         });
                         break;
                     }
+#pragma warning restore CS0618
                 case HubType.JwtAuthentication:
                     {
                         app.UseJwtMiddleware();
@@ -105,6 +117,16 @@ namespace WART_Core.Middleware
         /// <param name="hubName">The custom SignalR hub name (URL path).</param>
         /// <returns>The updated IApplicationBuilder to continue configuration.</returns>
         /// <exception cref="ArgumentException">Thrown when the hub name is null or empty.</exception>
+        /// <remarks>
+        /// <b>SECURITY WARNING:</b> This overload maps an unauthenticated SignalR hub that broadcasts
+        /// live API request and response payloads to every connected client with no credential check.
+        /// Use <see cref="UseWartMiddleware(IApplicationBuilder, string, HubType)"/> with
+        /// <c>HubType.JwtAuthentication</c> or <c>HubType.CookieAuthentication</c> instead.
+        /// See https://github.com/engineering87/WART/security/advisories
+        /// </remarks>
+        [Obsolete("UseWartMiddleware(string) without authentication broadcasts all API events to any anonymous client and is insecure. " +
+                  "Use UseWartMiddleware(hubName, HubType.JwtAuthentication) or UseWartMiddleware(hubName, HubType.CookieAuthentication) instead. " +
+                  "See https://github.com/engineering87/WART/security/advisories")]
         public static IApplicationBuilder UseWartMiddleware(this IApplicationBuilder app, string hubName)
         {
             if (string.IsNullOrWhiteSpace(hubName))
@@ -132,6 +154,16 @@ namespace WART_Core.Middleware
         /// <param name="hubNameList">The list of custom SignalR hub names (URL paths).</param>
         /// <returns>The updated IApplicationBuilder to continue configuration.</returns>
         /// <exception cref="ArgumentException">Thrown when the hub name list is null.</exception>
+        /// <remarks>
+        /// <b>SECURITY WARNING:</b> This overload maps unauthenticated SignalR hubs that broadcast
+        /// live API request and response payloads to every connected client with no credential check.
+        /// Use <see cref="UseWartMiddleware(IApplicationBuilder, IEnumerable{string}, HubType)"/> with
+        /// <c>HubType.JwtAuthentication</c> or <c>HubType.CookieAuthentication</c> instead.
+        /// See https://github.com/engineering87/WART/security/advisories
+        /// </remarks>
+        [Obsolete("UseWartMiddleware(IEnumerable<string>) without authentication broadcasts all API events to any anonymous client and is insecure. " +
+                  "Use UseWartMiddleware(hubNameList, HubType.JwtAuthentication) or UseWartMiddleware(hubNameList, HubType.CookieAuthentication) instead. " +
+                  "See https://github.com/engineering87/WART/security/advisories")]
         public static IApplicationBuilder UseWartMiddleware(this IApplicationBuilder app, IEnumerable<string> hubNameList)
         {
             ArgumentNullException.ThrowIfNull(hubNameList);
@@ -177,6 +209,7 @@ namespace WART_Core.Middleware
             switch (hubType)
             {
                 default:
+#pragma warning disable CS0618 // Internal routing — intentional fallback to no-auth mode
                 case HubType.NoAuthentication:
                     {
                         app.UseEndpoints(endpoints =>
@@ -186,6 +219,7 @@ namespace WART_Core.Middleware
                         });
                         break;
                     }
+#pragma warning restore CS0618
                 case HubType.JwtAuthentication:
                     {
                         app.UseJwtMiddleware();
@@ -235,6 +269,7 @@ namespace WART_Core.Middleware
             switch (hubType)
             {
                 default:
+#pragma warning disable CS0618 // Internal routing — intentional fallback to no-auth mode
                 case HubType.NoAuthentication:
                     app.UseEndpoints(endpoints =>
                     {
@@ -243,6 +278,7 @@ namespace WART_Core.Middleware
                             endpoints.MapHub<WartHub>(path);
                     });
                     break;
+#pragma warning restore CS0618
 
                 case HubType.JwtAuthentication:
                     app.UseJwtMiddleware();

--- a/src/WART-Core/Middleware/WartServiceCollectionExtension.cs
+++ b/src/WART-Core/Middleware/WartServiceCollectionExtension.cs
@@ -1,4 +1,4 @@
-ï»¿// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
+// (c) 2021 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -26,6 +26,17 @@ namespace WART_Core.Middleware
         /// </summary>
         /// <param name="services">The IServiceCollection to configure.</param>
         /// <returns>The updated IServiceCollection with WART middleware dependencies.</returns>
+        /// <remarks>
+        /// <b>SECURITY WARNING:</b> This overload configures an unauthenticated SignalR hub that
+        /// broadcasts live API request and response payloads to every connected client with no
+        /// credential check. Any anonymous network client can connect and receive sensitive data.
+        /// Use <see cref="AddWartMiddleware(IServiceCollection, HubType, string)"/> with
+        /// <c>HubType.JwtAuthentication</c> or <c>HubType.CookieAuthentication</c> instead.
+        /// See https://github.com/engineering87/WART/security/advisories
+        /// </remarks>
+        [Obsolete("AddWartMiddleware() without authentication broadcasts all API events to any anonymous client and is insecure. " +
+                  "Use AddWartMiddleware(HubType.JwtAuthentication, tokenKey) or AddWartMiddleware(HubType.CookieAuthentication) instead. " +
+                  "See https://github.com/engineering87/WART/security/advisories")]
         public static IServiceCollection AddWartMiddleware(this IServiceCollection services)
         {
             // Configure forwarded headers to support proxy scenarios (X-Forwarded-* headers).
@@ -81,12 +92,14 @@ namespace WART_Core.Middleware
             switch(hubType)
             {
                 default:
+#pragma warning disable CS0618 // Internal routing — intentional fallback to no-auth mode
                 case HubType.NoAuthentication:
                     {
                         // If no authentication is required, configure WART middleware without authentication.
                         services.AddWartMiddleware();
                         break;
                     }
+#pragma warning restore CS0618
                 case HubType.JwtAuthentication:
                     {
                         // If authentication is required, configure JWT middleware for authentication.

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/engineering87/WART</RepositoryUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageLicenseExpression></PackageLicenseExpression>
-    <Version>7.0.0</Version>
+    <Version>7.1.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
@@ -20,7 +20,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Core/WART-Core.csproj
+++ b/src/WART-Core/WART-Core.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-MinimalApi/WART-MinimalApi.csproj
+++ b/src/WART-MinimalApi/WART-MinimalApi.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -14,14 +14,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WART-Tests/WART-Tests.csproj
+++ b/src/WART-Tests/WART-Tests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WART-WebApiRealTime/WART-Api.csproj
+++ b/src/WART-WebApiRealTime/WART-Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

This PR introduces security hardening fixes for `WART-Core` related to SignalR group subscription authorization and unauthenticated event broadcast.

## Changes

### 🔒 Fix: Unauthorized SignalR group subscription

Any client could self-assign to an arbitrary SignalR group via query string with no authorization check, on all three hub variants.

- Added `IsGroupSubscriptionAllowed()` virtual guard to `WartHubBase`
- `WartHub` blocks group subscriptions entirely (unauthenticated hub)
- `WartHubJwt` and `WartHubCookie` allow group subscription only for authenticated principals

### 🔒 Fix: Unauthenticated broadcast of API data

The default configuration mapped an unauthenticated SignalR hub broadcasting full API request/response payloads to every connected client with no credential check.

- `HubType.NoAuthentication`, `AddWartMiddleware()` and all no-auth `UseWartMiddleware()` overloads marked `[Obsolete]` with security warning
- All warnings reference https://github.com/engineering87/WART/security/advisories

### 🔑 Hardening: JWT validation

- `AddJwtMiddleware` now accepts optional `validIssuer` and `validAudience` parameters
- Fully backward compatible

### 📦 Version bump: `7.0.0` → `7.1.0`

## Testing

- ✅ All 71 existing tests pass with no regressions
- ✅ Build clean, no unexpected warnings